### PR TITLE
Preserve SDPA for CoreML

### DIFF
--- a/backends/apple/coreml/partition/coreml_partitioner.py
+++ b/backends/apple/coreml/partition/coreml_partitioner.py
@@ -3,7 +3,7 @@
 # Please refer to the license found in the LICENSE file in the root directory of the source tree.
 
 import logging
-from typing import List, Optional
+from typing import Callable, List, Optional, Tuple
 
 import coremltools as ct
 
@@ -62,6 +62,7 @@ class CoreMLPartitioner(Partitioner):
         skip_ops_for_coreml_delegation: Optional[List[str]] = None,
         compile_specs: Optional[List[CompileSpec]] = None,
         take_over_mutable_buffer: Optional[bool] = True,
+        ops_not_to_decompose: List[torch._ops.OpOverload] = [torch.ops.aten.scaled_dot_product_attention.default],
     ) -> None:
         if skip_ops_for_coreml_delegation is None:
             skip_ops_for_coreml_delegation = []
@@ -71,6 +72,12 @@ class CoreMLPartitioner(Partitioner):
             compile_specs=compile_specs if compile_specs is not None else [],
         )
         self.take_over_mutable_buffer = take_over_mutable_buffer
+        self.ops_not_to_decompose = ops_not_to_decompose
+
+    def ops_to_not_decompose(
+        self, ep: ExportedProgram
+    ) -> Tuple[List[torch._ops.OpOverload], Optional[Callable[[torch.fx.Node], bool]]]:
+        return self.ops_not_to_decompose, None
 
     def partition(self, exported_program: ExportedProgram) -> PartitionResult:
         # Run the CapabilityBasedPartitioner to return the largest possible

--- a/backends/apple/coreml/test/test_coreml_partitioner.py
+++ b/backends/apple/coreml/test/test_coreml_partitioner.py
@@ -134,9 +134,51 @@ class TestCoreMLPartitioner(unittest.TestCase):
             "getitem",
         ]
 
+    def test_preserve_sdpa(self):
+        batch = 16
+        source_seq_len = 8
+        target_seq_len = 32
+        d_k = 64
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def forward(self, query, key, value):
+                return torch.ops.aten.scaled_dot_product_attention.default(query, key, value)
+            
+        model = Model()
+        model.eval()
+
+        q = torch.rand(batch, target_seq_len, d_k)
+        k = torch.rand(batch, source_seq_len, d_k)
+        v = torch.rand(batch, source_seq_len, d_k)
+
+        example_inputs = (q, k, v)
+        exir_program_aten = torch.export.export(model, example_inputs)
+
+        compile_specs = CoreMLBackend.generate_compile_specs(
+            minimum_deployment_target=ct.target.iOS18
+        )
+        partitioner = CoreMLPartitioner(compile_specs=compile_specs)
+        delegated_program_manager = executorch.exir.program._program.to_edge_transform_and_lower(
+            exir_program_aten,
+            partitioner=[partitioner],
+            compile_config=self.edge_compile_config,
+        )
+        assert [
+            node.target.__name__
+            for node in delegated_program_manager.exported_program().graph.nodes
+            if node.op == "call_function"
+        ] == [
+            "executorch_call_delegate",
+            "getitem",
+        ]
+
 
 if __name__ == "__main__":
     test_runner = TestCoreMLPartitioner()
-    test_runner.test_add_sub_skip_mm()
-    test_runner.test_vit_skip_conv()
-    test_runner.test_buffer()
+    # test_runner.test_add_sub_skip_mm()
+    # test_runner.test_vit_skip_conv()
+    # test_runner.test_buffer()
+    test_runner.test_preserve_sdpa()

--- a/extension/llm/export/partitioner_lib.py
+++ b/extension/llm/export/partitioner_lib.py
@@ -6,6 +6,8 @@
 
 from typing import Optional
 
+import torch
+
 
 def get_xnnpack_partitioner():
     from executorch.backends.xnnpack.partition.xnnpack_partitioner import (
@@ -57,6 +59,7 @@ def get_mps_partitioner(use_kv_cache: bool = False):
 
 def get_coreml_partitioner(
     enable_state: bool = False,
+    preserve_sdpa: bool = True,
     embedding_quantize: Optional[str] = None,
     pt2e_quantize: Optional[str] = None,
     coreml_quantize: Optional[str] = None,
@@ -77,6 +80,9 @@ def get_coreml_partitioner(
     minimum_deployment_target = ct.target.iOS15
     # In Core ML, stateful execution is introduced in iOS 18
     if enable_state:
+        minimum_deployment_target = max(minimum_deployment_target, ct.target.iOS18)
+    # In Core ML, sdpa op is introduced in iOS 18
+    if preserve_sdpa:
         minimum_deployment_target = max(minimum_deployment_target, ct.target.iOS18)
     # In Core ML, quantization is introduced in iOS 16
     if embedding_quantize is not None or pt2e_quantize is not None:
@@ -115,6 +121,7 @@ def get_coreml_partitioner(
     return CoreMLPartitioner(  # pyre-fixme[16]
         compile_specs=compile_specs,
         take_over_mutable_buffer=enable_state,
+        ops_not_to_decompose=[torch.ops.aten.scaled_dot_product_attention.default] if preserve_sdpa else [],
     )
 
 


### PR DESCRIPTION
## Motivation
Starting from iOS18, CoreML has added SDPA op, so there is no longer need to decompose torch SDPA

## Solution
Following https://github.com/pytorch/executorch/pull/3483, add `ops_not_to_decompose` in CoreML partitioner, then use `to_edge_transform_and_lower` API in llama export

## PS
Will need to merge https://github.com/pytorch/executorch/pull/5228 before this